### PR TITLE
MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,6 @@ graft estnltk/vabamorf/dct
 graft estnltk/mw_verbs/res
 graft estnltk/converters
 graft estnltk/estner
+graft estnltk/rewriting/syntax_preprocessing/rules_files
+graft estnltk/rewriting/postmorph/rules_files
+graft estnltk/rewriting/premorph/rules_files


### PR DESCRIPTION
Et tekstifailid/mitte *.py failid buildprotsessist läbi läheksid, peavad nad olema kataloogis, mis on MANIFEST.in failis loetletud.
https://docs.python.org/3/distutils/sourcedist.html#specifying-the-files-to-distribute

Teine võimalus oleks loetleda sellised failid setup.py-s https://docs.python.org/3/distutils/setupscript.html#installing-package-data